### PR TITLE
Bugfix -  Simulates local store and closes chat on widget delete

### DIFF
--- a/frontend/src/init/helpers.ts
+++ b/frontend/src/init/helpers.ts
@@ -1,0 +1,19 @@
+import { APP_ID } from '../config';
+
+const loadBreakoutWidgets = async () => {
+    
+    let state = []
+    const boardObjects = await miro.board.widgets.get();
+
+    //@ts-ignore
+    state = boardObjects.reduce((acc, cur) => {
+        if (cur.metadata[APP_ID]?.isBreakoutChatButton) {
+            acc.push(cur.id)
+        }
+        return acc
+    }, [])
+
+    return state
+}
+
+export default loadBreakoutWidgets;


### PR DESCRIPTION
### Description 

This PR fixes the chat not closing when the widget has been deleted.

**Approach**

1) Simulates a localStore with miro's builtin `__getRuntimeState` and `__setRuntimeState` 

2) When a widget is deleted the frontend listens via the `WIDGETS_DELETED` event and checks if the widgetId is a breakout widget - if it is it closes the left chat window.

**Resources**

[Miro event types](https://github.com/miroapp/app-examples/blob/master/miro.d.ts#L59)